### PR TITLE
RBF interpolator bug fixed

### DIFF
--- a/WDPhotTools/atmosphere_model_reader.py
+++ b/WDPhotTools/atmosphere_model_reader.py
@@ -529,7 +529,9 @@ class AtmosphereModelReader(object):
                         _x1 = np.log10(_x1)
 
                     return _atmosphere_interpolator(
-                        np.transpose(np.asarray([_x0, _x1], dtype="object")
+                        np.asarray([_x0, _x1], dtype="object").T.reshape(
+                        length0, 2
+                        )
                         )
                     )
 

--- a/WDPhotTools/atmosphere_model_reader.py
+++ b/WDPhotTools/atmosphere_model_reader.py
@@ -414,7 +414,7 @@ class AtmosphereModelReader(object):
                         _x = np.log10(_x)
 
                     return _atmosphere_interpolator(
-                        np.array([_logg, _x], dtype=object).reshape(length, 2)
+                        np.array([_logg, _x], dtype="object").T.reshape(length, 2)
                     )
 
             else:

--- a/WDPhotTools/atmosphere_model_reader.py
+++ b/WDPhotTools/atmosphere_model_reader.py
@@ -529,8 +529,7 @@ class AtmosphereModelReader(object):
                         _x1 = np.log10(_x1)
 
                     return _atmosphere_interpolator(
-                        np.asarray([_x0, _x1], dtype="object").reshape(
-                            length0, 2
+                        np.transpose(np.asarray([_x0, _x1], dtype="object")
                         )
                     )
 

--- a/WDPhotTools/atmosphere_model_reader.py
+++ b/WDPhotTools/atmosphere_model_reader.py
@@ -532,7 +532,6 @@ class AtmosphereModelReader(object):
                         np.asarray([_x0, _x1], dtype="object").T.reshape(
                         length0, 2
                         )
-                        )
                     )
 
             else:

--- a/test/test_fitter.py
+++ b/test/test_fitter.py
@@ -756,3 +756,5 @@ def test_chi2_minimization_red_interpolated():
     assert np.isclose(
         ftr.results["H"].x, np.array([13000.0, 7.5]), rtol=1e-02, atol=1e-02
     ).all()
+
+#ykw


### PR DESCRIPTION
RBF interpolator bug fixed

return _atmosphere_interpolator(
                        np.asarray([_x0, _x1], dtype="object").T.reshape(
                            length0, 2
                        )
                    )
changed for both len(independent) == 1 and len(independent) == 2