### PR TITLE
replace pkg_resources with importlib

### DIFF
--- a/src/WDPhotTools/__init__.py
+++ b/src/WDPhotTools/__init__.py
@@ -3,11 +3,11 @@
 
 """Initialise the import"""
 
-from pkg_resources import get_distribution, DistributionNotFound
+from importlib.metadata import version, PackageNotFoundError
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = version(__name__)
+except PackageNotFoundError:
     pass  # package is not installed
 
 
@@ -34,3 +34,4 @@ __all__ = [
 ]
 __credits__ = ["K W Yuen", "M Green", "W Li"]
 __status__ = "Production"
+

--- a/src/WDPhotTools/util.py
+++ b/src/WDPhotTools/util.py
@@ -3,10 +3,9 @@
 
 """Some utility class/functions"""
 
-import glob
-import pkg_resources
-
 import numpy as np
+
+from importlib.resources import files
 
 
 def get_uncertainty_least_squares(res):
@@ -42,7 +41,8 @@ def load_ms_lifetime_datatable(filename):
     """
 
     datatable = np.loadtxt(
-        glob.glob(pkg_resources.resource_filename("WDPhotTools", f"ms_lifetime/{filename}"))[0],
-        delimiter=",",
+        str(files("WDPhotTools").joinpath("ms_lifetime", filename)),
+        delimiter=","
     )
     return datatable
+


### PR DESCRIPTION
Hi @cylammarco, Hope you are doing well.
I have installed your package via
```pip install git+https://github.com/cylammarco/WDPhotTools.git@dev```
and it worked perfectly but it warns me about pkg_resources every time I use it in my scripts:
UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81

so I have replaced it with builtin module importlib but I do not know how to test it. :)
I was wondering if you could check it out?
Thanks you for this package it helped me a lot.